### PR TITLE
Update version bound on HUnit

### DIFF
--- a/force-elems/force-elems.cabal
+++ b/force-elems/force-elems.cabal
@@ -25,7 +25,7 @@ test-suite force-elems-test
   hs-source-dirs: test
   ghc-options: -O2
   build-depends: base >=4.7 && <5,
-                 HUnit,
+                 HUnit >= 1.6.1.0,
                  force-elems
   default-language: Haskell2010
 


### PR DESCRIPTION
HUnit only has `runTestTTAndExit` beginning with 1.6.1.0.

Alternatively, we could copy the defn of `runTestTTAndExit`, it's quite small.